### PR TITLE
Upgrade to Feathers Buzzard (v3)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,8 @@
 const Proto = require('uberproto');
-const filter = require('feathers-query-filters');
-const errors = require('feathers-errors');
+const errors = require('@feathersjs/errors');
 const cloneDeep = require('clone-deep');
 
-const { sorter, select, _ } = require('feathers-commons');
+const { sorter, select, filterQuery, _ } = require('@feathersjs/commons');
 
 const sift = require('sift');
 
@@ -32,7 +31,7 @@ class Service {
 
   // Find without hooks and mixins that can be used internally and always returns
   // a pagination object
-  _find (params, getFilter = filter) {
+  _find (params, getFilter = filterQuery) {
     const { query, filters } = getFilter(params.query || {});
     const map = _select(params);
     let values = _.values(this.store);
@@ -68,7 +67,7 @@ class Service {
   find (params) {
     const paginate = typeof params.paginate !== 'undefined' ? params.paginate : this.paginate;
     // Call the internal find with query parameter that include pagination
-    const result = this._find(params, query => filter(query, paginate));
+    const result = this._find(params, query => filterQuery(query, paginate));
 
     if (!(paginate && paginate.default)) {
       return result.then(page => page.data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,54 +4,75 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/express": {
-      "version": "4.0.37",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.37.tgz",
-      "integrity": "sha512-tIULTLzQpFFs5/PKnFIAFOsXQxss76glppbVKR3/jddPK26SBsD5HF5grn5G2jOGtpRWSBvYmDYoduVv+3wOXg==",
-      "dev": true,
+    "@feathersjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-/2Fevm/g0hIe79A81eMOScPNtoWIuHk1LwXCLJGeuGKoTUnzd/xJLSFesSq7dlePDtwMtuR8apnB1CM49iCy+g=="
+    },
+    "@feathersjs/errors": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.2.0.tgz",
+      "integrity": "sha512-4xsE7OyzxGvs2hyG19nf2qb4rV2nWoWbQ6/FnDIYrNHi7M9kOy+deLwNhKnXa4r/hg3xf+AVpC8kBjUQjWYWHA==",
       "requires": {
-        "@types/express-serve-static-core": "4.0.52",
-        "@types/serve-static": "1.7.32"
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
-    "@types/express-serve-static-core": {
-      "version": "4.0.52",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.52.tgz",
-      "integrity": "sha512-UpN389YLcQEIn1t4Kxc8TlCrg43r6o8IcF57LvmbCGNhWzz0dEg4AaUsN6IHrrSjPzPmmJ1FLYXGPP/expXOWg==",
+    "@feathersjs/express": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-1.1.2.tgz",
+      "integrity": "sha512-oxXZs3QAZB80fBajb7nh3Pbongm8ESXVnJw1EuX7fui4JOXh2qGw9hf8e3xKAZ/fmkHmgofdA1A3iqIzBg3Isw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@feathersjs/commons": "1.3.0",
+        "@feathersjs/errors": "3.2.0",
+        "debug": "3.1.0",
+        "express": "4.16.2",
+        "uberproto": "1.2.0"
       }
     },
-    "@types/mime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.1.tgz",
-      "integrity": "sha512-rek8twk9C58gHYqIrUlJsx8NQMhlxqHzln9Z9ODqiNgv3/s+ZwIrfr+djqzsnVM12xe9hL98iJ20lj2RvCBv6A==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "8.0.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
-      "integrity": "sha512-HupkFXEv3O3KSzcr3Ylfajg0kaerBg1DyaZzRBBQfrU3NN1mTBRE7sCveqHwXLS5Yrjvww8qFzkzYQQakG9FuQ==",
-      "dev": true
-    },
-    "@types/serve-static": {
-      "version": "1.7.32",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.32.tgz",
-      "integrity": "sha512-WpI0g7M1FiOmJ/a97Qrjafq2I938tjAZ3hZr9O7sXyA6oUhH3bqUNZIt7r1KZg8TQAKxcvxt6JjQ5XuLfIBFvg==",
+    "@feathersjs/feathers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.0.1.tgz",
+      "integrity": "sha512-uRvzpnpwdW31+hQ67sGPQAQm09hmZrw1nc5om9yoSTouszjREcM2qusJkyWXN67/8Uythge6OjlYIP0NFJHVaw==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.52",
-        "@types/mime": "1.3.1"
+        "@feathersjs/commons": "1.3.0",
+        "debug": "3.1.0",
+        "events": "1.1.1",
+        "uberproto": "1.2.0"
       }
     },
-    "@types/socket.io": {
-      "version": "1.4.30",
-      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-1.4.30.tgz",
-      "integrity": "sha512-YkaCkyqbbxNa1Hpix1YAVhPG9X/PDat75l96Hbrf3uDoQ9u/9aDjgG2N+KqW8DpV8U70VmVEyA2/ilbTA/np6w==",
+    "@feathersjs/socket-commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/socket-commons/-/socket-commons-3.0.1.tgz",
+      "integrity": "sha512-/WgXC7tODg16uCGK5SKQYg3NvCdchJQyvBD1F0ljKWCee8N+Ep5TprN+i0/Ip4hAwWsQMQ7HIKBKdDvJ32aYyA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@feathersjs/errors": "3.2.0",
+        "debug": "3.1.0",
+        "lodash": "4.17.4",
+        "url-pattern": "1.0.3"
+      }
+    },
+    "@feathersjs/socketio": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/socketio/-/socketio-3.0.1.tgz",
+      "integrity": "sha512-YZFpj52tu1QrO/n74CyeceCZ20dr3CIN6cGYHTbvl+As+aNY7yzQTvUVKBOrOfLUu/tuI4u1W+BzH+30+9ySSA==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/socket-commons": "3.0.1",
+        "debug": "3.1.0",
+        "socket.io": "2.0.4"
       }
     },
     "abbrev": {
@@ -233,6 +254,12 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -783,9 +810,10 @@
       }
     },
     "debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
-      "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -934,18 +962,18 @@
       "dev": true
     },
     "engine.io": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.1.tgz",
-      "integrity": "sha1-CAUf+5UZB6MmfnLgvLPQ83fkZgs=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.4.tgz",
+      "integrity": "sha1-PQIRtwpVLOhB/8fahiezAamkFi4=",
       "dev": true,
       "requires": {
         "accepts": "1.3.3",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "engine.io-parser": "2.1.1",
         "uws": "0.14.5",
-        "ws": "2.3.1"
+        "ws": "3.3.2"
       },
       "dependencies": {
         "accepts": {
@@ -959,9 +987,9 @@
           }
         },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -970,29 +998,28 @@
       }
     },
     "engine.io-client": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.1.tgz",
-      "integrity": "sha1-QVqYUrrbFPoAj6PvHjFgjbZ2EyU=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.4.tgz",
+      "integrity": "sha1-T88TcLRxY70s6b4nM5ckMDUNTqE=",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "engine.io-parser": "2.1.1",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
-        "parsejson": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "2.3.1",
-        "xmlhttprequest-ssl": "1.5.3",
+        "ws": "3.3.2",
+        "xmlhttprequest-ssl": "1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1443,54 +1470,74 @@
       "dev": true
     },
     "express": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
-      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.0.4",
-        "fresh": "0.5.0",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.4",
-        "serve-static": "1.12.4",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.1.1"
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.15"
+          }
+        },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
-        "qs": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         }
       }
@@ -1513,34 +1560,10 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "feathers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/feathers/-/feathers-2.2.0.tgz",
-      "integrity": "sha512-jSe3l6s6ez1kUCpg8E2nTdXsgSdps+juc0dH9/NMNRYAd1QgHuKPF1yN2HdcF6Woyva5OsI31+DMG46IAnd0uw==",
-      "dev": true,
-      "requires": {
-        "@types/express": "4.0.37",
-        "babel-runtime": "6.26.0",
-        "debug": "3.0.1",
-        "events": "1.1.1",
-        "express": "4.15.4",
-        "feathers-commons": "0.8.7",
-        "rubberduck": "1.1.1",
-        "uberproto": "1.2.0"
-      }
-    },
     "feathers-commons": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/feathers-commons/-/feathers-commons-0.8.7.tgz",
       "integrity": "sha1-EcbyW1N3RamD6NYVUtfbiTLVN4I="
-    },
-    "feathers-errors": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/feathers-errors/-/feathers-errors-2.9.2.tgz",
-      "integrity": "sha512-qwIX97bNW7+1tWVG073+omUA0rCYKJtTtwuzTrrvfrtdr8J8Dk1Fy4iaV9Fa6/YBD5AZu0lsplPE0iu4u/d4GQ==",
-      "requires": {
-        "debug": "3.0.1"
-      }
     },
     "feathers-query-filters": {
       "version": "2.1.2",
@@ -1548,29 +1571,6 @@
       "integrity": "sha1-zbGCJNteGcwBQNUoEI4JCNXrBlQ=",
       "requires": {
         "feathers-commons": "0.8.7"
-      }
-    },
-    "feathers-rest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/feathers-rest/-/feathers-rest-1.8.0.tgz",
-      "integrity": "sha512-HLkmwJO4YqEpp7LRE7PbDjVmB03CS8KXqGslxsiQgyQ+bD3g2tGIhc0O9r2yQt4HD/QFNpi9jtWe05dS1PnAVA==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.2",
-        "qs": "6.5.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "feathers-service-tests": {
@@ -1582,52 +1582,6 @@
         "chai": "3.5.0",
         "request": "2.81.0",
         "request-promise": "4.2.1"
-      }
-    },
-    "feathers-socket-commons": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/feathers-socket-commons/-/feathers-socket-commons-2.4.0.tgz",
-      "integrity": "sha1-Bi79V/mocWZEFFuZOl9ycJlp8eE=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "feathers-socketio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/feathers-socketio/-/feathers-socketio-2.0.0.tgz",
-      "integrity": "sha1-zmLjNifeqtUyeeT5tnzawPLPSd4=",
-      "dev": true,
-      "requires": {
-        "@types/socket.io": "1.4.30",
-        "debug": "2.6.8",
-        "feathers-socket-commons": "2.4.0",
-        "socket.io": "2.0.3",
-        "uberproto": "1.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "figures": {
@@ -1661,12 +1615,12 @@
       }
     },
     "finalhandler": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
@@ -1676,9 +1630,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1743,15 +1697,15 @@
       }
     },
     "forwarded": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.1.tgz",
-      "integrity": "sha1-ik4wxkCwU5U5mjVJxzAldygEiWE=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs.realpath": {
@@ -2054,9 +2008,9 @@
       }
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
       "dev": true
     },
     "is-arrayish": {
@@ -2542,9 +2496,9 @@
       "dev": true
     },
     "mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mime-db": {
@@ -2801,15 +2755,6 @@
         "error-ex": "1.3.1"
       }
     },
-    "parsejson": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
-      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
-    },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
@@ -2969,13 +2914,13 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.1",
-        "ipaddr.js": "1.4.0"
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
       }
     },
     "punycode": {
@@ -3177,12 +3122,6 @@
         "glob": "7.1.2"
       }
     },
-    "rubberduck": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rubberduck/-/rubberduck-1.1.1.tgz",
-      "integrity": "sha1-zSzaS4ZxeBNer8mVpxOE9fdD2wI=",
-      "dev": true
-    },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
@@ -3235,20 +3174,20 @@
       "dev": true
     },
     "send": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "fresh": "0.5.0",
+        "fresh": "0.5.2",
         "http-errors": "1.6.2",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
@@ -3256,9 +3195,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -3267,15 +3206,15 @@
       }
     },
     "serve-static": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
-      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.4"
+        "send": "0.16.1"
       }
     },
     "setprototypeof": {
@@ -3316,23 +3255,22 @@
       }
     },
     "socket.io": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.3.tgz",
-      "integrity": "sha1-Q1nwaiSTOua9CHeYr3jGgOrjReM=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
+      "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "engine.io": "3.1.1",
-        "object-assign": "4.1.1",
+        "debug": "2.6.9",
+        "engine.io": "3.1.4",
         "socket.io-adapter": "1.1.1",
-        "socket.io-client": "2.0.3",
+        "socket.io-client": "2.0.4",
         "socket.io-parser": "3.1.2"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -3347,17 +3285,17 @@
       "dev": true
     },
     "socket.io-client": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.3.tgz",
-      "integrity": "sha1-bK9K/5+FsZ/ZG2zhPWmttWT4hzs=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
+      "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
       "dev": true,
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "2.6.8",
-        "engine.io-client": "3.1.1",
+        "debug": "2.6.9",
+        "engine.io-client": "3.1.4",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
@@ -3368,9 +3306,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -3385,15 +3323,15 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "has-binary2": "1.0.2",
         "isarray": "2.0.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -3695,9 +3633,9 @@
       "optional": true
     },
     "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
     "uniq": {
@@ -3712,6 +3650,12 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
+    "url-pattern": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/url-pattern/-/url-pattern-1.0.3.tgz",
+      "integrity": "sha1-BAkpJHGyTyPFDWWkeTF5PStaz8E=",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3719,9 +3663,9 @@
       "dev": true
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
@@ -3738,9 +3682,9 @@
       "optional": true
     },
     "vary": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
@@ -3800,27 +3744,20 @@
       }
     },
     "ws": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-      "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
+      "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.0.1",
-        "ultron": "1.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        }
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "ultron": "1.1.1"
       }
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
-      "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.4.tgz",
+      "integrity": "sha1-BPVgkVcks4kIhxXMDteBPpZ3v1c=",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -46,19 +46,18 @@
     "lib": "lib"
   },
   "dependencies": {
+    "@feathersjs/commons": "^1.3.0",
+    "@feathersjs/errors": "^3.2.0",
     "clone-deep": "^2.0.0",
-    "feathers-commons": "^0.8.0",
-    "feathers-errors": "^2.0.1",
-    "feathers-query-filters": "^2.0.0",
     "sift": "^5.0.0",
     "uberproto": "^1.2.0"
   },
   "devDependencies": {
+    "@feathersjs/express": "^1.1.2",
+    "@feathersjs/feathers": "^3.0.1",
+    "@feathersjs/socketio": "^3.0.1",
     "body-parser": "^1.14.1",
-    "feathers": "^2.0.0-pre.4",
-    "feathers-rest": "^1.2.2",
     "feathers-service-tests": "^0.10.0",
-    "feathers-socketio": "^2.0.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^4.0.0",
     "semistandard": "^11.0.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 const { base } = require('feathers-service-tests');
-const errors = require('feathers-errors');
-const feathers = require('feathers');
+const errors = require('@feathersjs/errors');
+const feathers = require('@feathersjs/feathers');
 const assert = require('assert');
 
 const memory = require('../lib');


### PR DESCRIPTION
This updates the development dependencies to Feathers Buzzard. New release will stay compatible with previous versions of Feathers.

Previous versions of `feathers-memory` are also compatible with Feathers Buzzard.