### PR TITLE
Fix cloning of instances

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const _select = (...args) => {
   const base = select(...args);
 
   return function (result) {
-    return base(cloneDeep(result));
+    return base(cloneDeep(result, (obj) => JSON.parse(JSON.stringify(obj))));
   };
 };
 


### PR DESCRIPTION
I came across an issue whilst using oauth2 authentication. There was a failure because the profile from `passport-oauth2` wasn't being stored. I traced this back to here - the deep clone function used wasn't cloning the profile instance as it's not a plain object. This __seems__ to be the best place for a fix but obviously open to other ideas. Whilst it might be easier to fix at the `passport-outh2` stage I thought that might have adverse effects downstream. I haven't tested but it might be necessary to rollout this change to the other stores using `clone-deep`. I also tested lodash's cloneDeep and that works without any other changes - it could be preferable to simply swap to their implementation.

I'm new to feathers so excuse me if I don't know what I'm talking about! Showing a lot of promise so far - thanks a lot!

James

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: