### PR TITLE
Allow patch to update prop that is within the query

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ class Service extends AdapterService {
       
       this.store[currentId] = _.extend(this.store[currentId], _.omit(data, this.id));
 
-      return this._get(id, params);
+      return this._get(currentId, params);
     }
     
     

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,22 +101,19 @@ class Service extends AdapterService {
   async _patch (id, data, params = {}) {
     const patchEntry = entry => {
       const currentId = entry[this.id];
-      
+
       this.store[currentId] = _.extend(this.store[currentId], _.omit(data, this.id));
 
-      return this._get(currentId, params);
-    }
-    
-    
+      return _select(this.store[currentId], params, this.id);
+    };
+
     if (id === null) {
       const entries = await this.getEntries(params);
 
-      return Promise.all(entries.map(patchEntry));
+      return entries.map(patchEntry);
     }
 
-    await this._get(id, params); // Will throw an error if not found
-    
-    return patchEntry(data); 
+    return patchEntry(await this._get(id, params)); // Will throw an error if not found
   }
 
   // Remove without hooks and mixins that can be used internally

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ class Service extends AdapterService {
       const entries = await this.getEntries(params);
 
       return Promise.all(entries.map(
-        current => this._patch(current[this.id], data, params))
+        current => this._patch(current[this.id], data))
       );
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,19 +99,24 @@ class Service extends AdapterService {
   }
 
   async _patch (id, data, params = {}) {
+    const patchEntry = entry => {
+      const currentId = entry[this.id];
+      
+      this.store[currentId] = _.extend(this.store[currentId], _.omit(data, this.id));
+
+      return this._get(id, params);
+    }
+    
+    
     if (id === null) {
       const entries = await this.getEntries(params);
 
-      return Promise.all(entries.map(
-        current => this._patch(current[this.id], data))
-      );
+      return Promise.all(entries.map(patchEntry));
     }
 
     await this._get(id, params); // Will throw an error if not found
-
-    this.store[id] = _.extend(this.store[id], _.omit(data, this.id));
-
-    return this._get(id, params);
+    
+    return patchEntry(data); 
   }
 
   // Remove without hooks and mixins that can be used internally

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -95,6 +95,24 @@ describe('Feathers Memory Service', () => {
     await people.remove(person.id.toString());
   });
 
+  it('patch record with prop also in query', async () => {
+    app.use('/animals', memory({ multi: true }));
+    const animals = app.service('animals');
+    await animals.create([{
+      type: 'cat',
+      age: 30
+    }, {
+      type: 'dog',
+      age: 10
+    }]);
+
+    const [updated] = await animals.patch(null, { age: 40 }, { query: { age: 30 } });
+
+    assert.strictEqual(updated.age, 40);
+
+    await animals.remove(null, {});
+  });
+
   it('allows to pass custom find and sort matcher', async () => {
     let sorterCalled = false;
     let matcherCalled = false;


### PR DESCRIPTION
Closes #92 

This allows the ability to patch a property which is also within the query ie: 
```js
service.patch(null, { age: 10 }, { query: { age: 20 } })
```