### PR TITLE
fix: TypeError: this.options.matcher is not a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const errors = require('@feathersjs/errors');
 const { _ } = require('@feathersjs/commons');
 const { sorter, select, AdapterService } = require('@feathersjs/adapter-commons');
-const sift = require('sift').default;
+const sift = require('sift').default | require('sift');
 
 const _select = (data, ...args) => {
   const base = select(...args);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const errors = require('@feathersjs/errors');
 const { _ } = require('@feathersjs/commons');
 const { sorter, select, AdapterService } = require('@feathersjs/adapter-commons');
-const sift = require('sift').default | require('sift');
+const sift = require('sift');
 
 const _select = (data, ...args) => {
   const base = select(...args);


### PR DESCRIPTION
In a `typescript` project using `esModuleInterop` using `rollup` as bundler `require('sift')` doesn't have a `default` export.

I don't know how to fix this for all cases. Any idea?

Thanks!